### PR TITLE
let's versus lets

### DIFF
--- a/www/website-content/pages/use-cases/desktop/index.html
+++ b/www/website-content/pages/use-cases/desktop/index.html
@@ -5,7 +5,7 @@
 		<p class="lead">With Haxe you can use the language, libraries and concepts you are familiar with to create full-featured desktop apps.</p>
 		<p>When aiming for apps with a native look, you can use the Waxe project, which uses WxWidgets to build native UI on each desktop platform.  You can also use frameworks such as Spring on the Java target for a native look, though it is emulated.</p>
 		<p>The most flexible interfaces can be achieved using NME or OpenFL, where you create your app using the Flash API.  Libraries such as HaxeUI and StablexUI give you frameworks for crafting your User Interface.</p>
-		<p>If your strength is with HTML5, you may appreciate the Node-Webkit approach, which let's you build a HTML5 web-app, but with full access to the Node APIs so you can interact with the user's system.</p>
+		<p>If your strength is with HTML5, you may appreciate the Node-Webkit approach, which lets you build a HTML5 web-app, but with full access to the Node APIs so you can interact with the user's system.</p>
 	</div>
 	<div class="span6">
 		<blockquote>
@@ -43,7 +43,7 @@
 			</li>
 			<li>
 				<h6><a href="https://github.com/as3boyan/node-webkit-haxelib">Node Webkit</a></h6>
-				<p>Node Webkit provides let's you run a Webkit shell on the desktop, meaning you can use Haxe and HTML5 / JS technologies to build your app.  It provides full access to the NodeJS APIs so your app can integrate with the system.</p>
+				<p>Node Webkit lets you run a Webkit shell on the desktop, meaning you can use Haxe and HTML5 / JS technologies to build your app.  It provides full access to the NodeJS APIs so your app can integrate with the system.</p>
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
let's = "let us"
lets = "allows

I included another fix (removing "provides") in the same pull request, since I'm assuming you'll want both changes—if I'm wrong and you want one but not the other I can separate them.  It looks like the "provides" was accidentally left over from a previous edit.  (For instance, I'm guessing it used to say something like "Node Webkit provides a Webkit shell on the desktop" or something like that.)
