### PR TITLE
CSS fix for broken navigation arrows

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -392,13 +392,13 @@ ul.logos li.arr {
 	float: left;
 }
 .prev-link:before {
-	content: "« ";
+	content: "&laquo; ";
 }
 .next-link {
 	float: right;
 }
 .next-link:after {
-	content: " »";
+	content: " &raquo;";
 }
 
 /**


### PR DESCRIPTION
Fixes broken navigation arrows on navigation in Google Chrome. Now renders as `Â»`
