### PR TITLE
Homepage facelift, different header color

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -193,7 +193,7 @@ a.anch {
 	bottom: 3px;
 	background: none;
 	box-shadow: none;
-	border: 2px solid rgb(234, 130, 32);
+	border: 1px solid rgba(234, 130, 32, .3);
 	color: rgb(234, 130, 32);
 	width: 204px;
 	height: 54px;
@@ -290,17 +290,17 @@ a.anch {
 }
 .section.dark.head {
 	/* fallback */
-	background-color: rgb(168,75,56);
+	background-color: rgb(45,45,55);
 	background-repeat: no-repeat;
 
 	/* Safari 4-5, Chrome 1-9 */
-	background: -webkit-gradient(radial, 50% 80%, 0, center center, 100, from(rgb(183,77,49)), to(rgb(100,33,38)));
+	background: -webkit-gradient(radial, 50% 80%, 0, center center, 100, from(rgb(68,68,70)), to(rgb(8,8,18)));
 	/* Safari 5.1+, Chrome 10+ */
-	background: -webkit-radial-gradient(50% 80%, circle, rgb(183,77,49), rgb(100,33,38));
+	background: -webkit-radial-gradient(50% 80%, circle, rgb(68,68,70), rgb(8,8,18));
 	/* Firefox 3.6+ */
-	background: -moz-radial-gradient(50% 80%, circle, rgb(183,77,49), rgb(100,33,38));
+	background: -moz-radial-gradient(50% 80%, circle, rgb(68,68,70), rgb(8,8,18));
 	/* IE 10 */
-	background: -ms-radial-gradient(50% 80%, circle, rgb(183,77,49), rgb(100,33,38));
+	background: -ms-radial-gradient(50% 80%, circle, rgb(68,68,70), rgb(8,8,18));
 }
 .head .head-logo {
 	display: block;
@@ -309,7 +309,7 @@ a.anch {
 }
 .head .head-content h1 {
 	font-weight: bold;
-	text-shadow: 0px 1px 0px rgb(88,27,32);
+	text-shadow: 0px 1px 0px rgb(38,38,48);
 	color: white;
 }
 .head .head-content .lead {


### PR DESCRIPTION
This is pure cosmetic, but I think this looks cooler and makes the logo stand out even more. 

![haxe-header-color](https://cloud.githubusercontent.com/assets/576184/6137166/06bd844e-b177-11e4-8fc8-8d8f15b2109f.png)
