### PR TITLE
Added a link to haxe compiler source code

### DIFF
--- a/www/website-content/pages/foundation/open-source.md
+++ b/www/website-content/pages/foundation/open-source.md
@@ -18,6 +18,8 @@ The license of the compiler does not affect the license of your own source code.
 
 [Click here to read the full GPLv2.0 License Text](https://www.gnu.org/licenses/gpl-2.0.html)
 
+[Click here to see Haxe Compiler source code](https://github.com/HaxeFoundation/haxe)
+
 <a name="std-library-license" class="anch"></a>
 
 ### The Haxe Standard Library: MIT


### PR DESCRIPTION
Maybe this link would be better located in a "Contribute" page, but I didn't find it so far.