### PR TITLE
Fixing ufront dead link

### DIFF
--- a/www/website-content/pages/use-cases/web/index.html
+++ b/www/website-content/pages/use-cases/web/index.html
@@ -50,7 +50,7 @@
 				<p>A collection of externs to interact with key JS projects, including NodeJS, Express, Socket.io and more.</p>
 			</li>
 			<li>
-				<h6><a href="http://ufront.net/">Ufront</a></h6>
+				<h6><a href="https://github.com/ufront/ufront">Ufront</a></h6>
 				<p>Ufront is a full-featured, extensible MVCA web framework that works on the client or server.</p>
 			</li>
 		</ul>


### PR DESCRIPTION
the ufront link was dead, redirecting to github repo