### PR TITLE
Compiler usage links

### DIFF
--- a/www/website-content/pages/documentation/introduction/toolkit-introduction.md
+++ b/www/website-content/pages/documentation/introduction/toolkit-introduction.md
@@ -9,7 +9,7 @@ To help you do this, the toolkit contains three main components:
 
 * the [Haxe Language](language-introduction.html) - a modern high-level, strictly typed programming language
 * the [Haxe Standard Library](stdlib-introduction.html) - a complete cross-platform standard library
-* the [Haxe Compiler](compiler-usage.html) - an incredibly fast cross-compiler 
+* the [Haxe Compiler](/manual/compiler-usage.html) - an incredibly fast cross-compiler 
 
 Apart from these features, the Haxe Toolkit also provides you with a range of additional tools that will make using Haxe even more effective.
 

--- a/www/website-content/pages/index.html
+++ b/www/website-content/pages/index.html
@@ -151,9 +151,9 @@
 
 				<div class="span4 links">
 					<ol>
-						<li><a href="/documentation/introduction/compiler-usage.html">Using the Haxe Compiler</a></li>
+						<li><a href="/manual/compiler-usage.html">Using the Haxe Compiler</a></li>
 						<li><a href="/documentation/introduction/compiler-targets.html">List of Supported Platforms</a></li>
-						<li><a href="/manual/compiler-reference.html">The Haxe Compiler Reference</a></li>
+						<li><a href="/manual/cr-features.html">The Haxe Compiler features</a></li>
 					</ol>
 				</div>
 			</div>

--- a/www/website-content/sitemap.json
+++ b/www/website-content/sitemap.json
@@ -37,16 +37,16 @@
 						"url": "documentation/introduction/compiler-targets.html"
 					},
 					{
-						"title": "Compiler Usage",
-						"url": "documentation/introduction/compiler-usage.html"
-					},
-					{
 						"title": "Editors and IDEs",
 						"url": "documentation/introduction/editors-and-ides.html"
 					},
 					{
 						"title": "Building Haxe",
 						"url": "documentation/introduction/building-haxe.html"
+					},
+					{
+						"title": "Compiler Usage",
+						"url": "manual/compiler-usage.html"
 					}
 				]
 			},


### PR DESCRIPTION
* Navigate to "Compiler usage" on manual page instead of "introduction" section
* Moved it to bottom of navigation too. In the end this whole section should be part of the manual but for time being this is decent solution?
* Changed "compiler-reference" link on homepage to "compiler-features", since we don't have a compiler reference page written.