### PR TITLE
Add build instructions for FreeBSD

### DIFF
--- a/www/website-content/pages/documentation/introduction/building-haxe.md
+++ b/www/website-content/pages/documentation/introduction/building-haxe.md
@@ -128,3 +128,14 @@ For subsequent compilations it is usually enough to recompile the Haxe sources w
 ```
 make -f Makefile.win haxe
 ```
+
+Building on FreeBSD
+-------
+
+1) Become root to install packages: `su -`
+2) Install ocaml, gmake, git: `ocaml ocaml-camlp4 gmake git`
+3) As your unprivileged user, check out the project: `cd ~ && git clone --recursive https://github.com/HaxeFoundation/haxe.git`
+4) Build your sources: `cd haxe && gmake`
+5) Optionally install it to the system: `su -` followed by `cd /home/username/haxe && gmake install`
+
+If you want to update, it's usually enough to just recompile the compiler by issueing `gmake haxe`.

--- a/www/website-content/pages/documentation/introduction/building-haxe.md
+++ b/www/website-content/pages/documentation/introduction/building-haxe.md
@@ -138,4 +138,4 @@ Building on FreeBSD
 4. Build your sources: `cd haxe && gmake`
 5. Optionally install it to the system: `su -` followed by `cd /home/username/haxe && gmake install`
 
-If you want to update, it's usually enough to just recompile the compiler by issueing `gmake haxe`.
+If you want to update, it's usually enough to just recompile the compiler by updating your checkout using `git pull` followed by issueing the command `gmake haxe`.

--- a/www/website-content/pages/documentation/introduction/building-haxe.md
+++ b/www/website-content/pages/documentation/introduction/building-haxe.md
@@ -132,10 +132,10 @@ make -f Makefile.win haxe
 Building on FreeBSD
 -------
 
-1) Become root to install packages: `su -`
-2) Install ocaml, gmake, git: `ocaml ocaml-camlp4 gmake git`
-3) As your unprivileged user, check out the project: `cd ~ && git clone --recursive https://github.com/HaxeFoundation/haxe.git`
-4) Build your sources: `cd haxe && gmake`
-5) Optionally install it to the system: `su -` followed by `cd /home/username/haxe && gmake install`
+1. Become root to install packages: `su -`
+2. Install ocaml, gmake, git: `pkg install ocaml ocaml-camlp4 gmake git`
+3. As your unprivileged user, check out the project: `cd ~ && git clone --recursive https://github.com/HaxeFoundation/haxe.git`
+4. Build your sources: `cd haxe && gmake`
+5. Optionally install it to the system: `su -` followed by `cd /home/username/haxe && gmake install`
 
 If you want to update, it's usually enough to just recompile the compiler by issueing `gmake haxe`.


### PR DESCRIPTION
Adds a simple instruction list to the page for compiling haxe from source on FreeBSD.