### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: php
+language: haxe
+
+haxe: "3.2.1"
+
+sudo: false
 
 branches:
   only:
@@ -7,15 +11,6 @@ branches:
     - travis
 
 before_install:
-  # Install haxe 3.1.3
-  - sudo apt-get update
-  - sudo apt-get install python-software-properties -y # for the next command
-  - sudo add-apt-repository ppa:eyecreate/haxe -y
-  - sudo apt-get update
-  - sudo apt-get install haxe -y
-  # Setup haxelib
-  - mkdir ~/haxelib
-  - haxelib setup ~/haxelib
   # We need unreleased versions of minject and thx.core for now to deal with a memory leak.
   - haxelib dev ufront-mvc submodules/ufront-mvc/
   - haxelib dev ufront-uftasks submodules/ufront-uftasks/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-# Key decryption based on instructions at:
-# http://pghalliday.com/github/ssh/travis-ci/2014/09/19/auto-build-and-deploy-github-pages-with-travis-ci.html
-
 branches:
   only:
     - master
@@ -19,11 +16,6 @@ before_install:
   # Setup haxelib
   - mkdir ~/haxelib
   - haxelib setup ~/haxelib
-  # Decrypt our SSH key
-  - openssl aes-256-cbc -K $encrypted_c7c1240b42e4_key -iv $encrypted_c7c1240b42e4_iv -in deploy_key.enc -out deploy_key -d
-  - chmod 600 deploy_key
-  - eval `ssh-agent -s`
-  - ssh-add deploy_key
   # We need unreleased versions of minject and thx.core for now to deal with a memory leak.
   - haxelib dev ufront-mvc submodules/ufront-mvc/
   - haxelib dev ufront-uftasks submodules/ufront-uftasks/
@@ -49,9 +41,17 @@ script:
   - haxelib run ufront build
 
 after_success:
-  - haxelib run ufront deploy
-  - wget http://haxe.org/update/manual/
-  - wget http://haxe.org/update/site/
+  # Key decryption based on instructions at:
+  # http://pghalliday.com/github/ssh/travis-ci/2014/09/19/auto-build-and-deploy-github-pages-with-travis-ci.html
+  - if [ -n "$encrypted_c7c1240b42e4_key" ]; then
+      openssl aes-256-cbc -K $encrypted_c7c1240b42e4_key -iv $encrypted_c7c1240b42e4_iv -in deploy_key.enc -out deploy_key -d;
+      chmod 600 deploy_key;
+      eval `ssh-agent -s`;
+      ssh-add deploy_key;
+      haxelib run ufront deploy;
+      wget http://haxe.org/update/manual/;
+      wget http://haxe.org/update/site/;
+    fi
 
 addons:
   ssh_known_hosts: haxe.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ haxe: "3.2.1"
 
 sudo: false
 
-branches:
-  only:
-    - master
-    - staging
-    - travis
-
 before_install:
   # We need unreleased versions of minject and thx.core for now to deal with a memory leak.
   - haxelib dev ufront-mvc submodules/ufront-mvc/
@@ -38,7 +32,7 @@ script:
 after_success:
   # Key decryption based on instructions at:
   # http://pghalliday.com/github/ssh/travis-ci/2014/09/19/auto-build-and-deploy-github-pages-with-travis-ci.html
-  - if [ -n "$encrypted_c7c1240b42e4_key" ]; then
+  - if [ -n "$encrypted_c7c1240b42e4_key" ] && ([ "$TRAVIS_BRANCH" = "master" ] || [ "$TRAVIS_BRANCH" = "staging" ] || [ "$TRAVIS_BRANCH" = "travis" ]); then
       openssl aes-256-cbc -K $encrypted_c7c1240b42e4_key -iv $encrypted_c7c1240b42e4_iv -in deploy_key.enc -out deploy_key -d;
       chmod 600 deploy_key;
       eval `ssh-agent -s`;


### PR DESCRIPTION
### Use `language: haxe`

Pinned haxe version to 3.2.1.
Note that we were using ppa:eyecreate/haxe, which has been updated to haxe 3.2.0 for quite some time. That means we were in fact using 3.2.0 instead of 3.1.3 as stated in .travis.yml.

### Allow testing on any branch

In order to do that, I've moved the key decryption logic to `after_success:`, fenced with a check on branch name.
It is made to allow people to use TravisCI for testing their own forks, which are often branched with different names.