### PR TITLE
HaxeLib -> Haxelib

### DIFF
--- a/www/website-content/sitemap.json
+++ b/www/website-content/sitemap.json
@@ -167,7 +167,7 @@
 				"url": "http://try.haxe.org/"
 			},
 			{
-				"title": "HaxeLib",
+				"title": "Haxelib",
 				"url": "http://lib.haxe.org/"
 			}
 		]


### PR DESCRIPTION
I think the navigation is the only place where "Haxelib" was camel-cased.