### PR TITLE
Make it clear that Haxe itself is typed

### DIFF
--- a/www/website-content/pages/documentation/introduction/compiler-targets.md
+++ b/www/website-content/pages/documentation/introduction/compiler-targets.md
@@ -3,6 +3,7 @@ Compiler Targets
 
 The following table gives an overview of available Haxe targets:
 
+
 Name | Kind | Static typing | Sys | Use Cases | Since
 --- | --- | --- | --- | --- | ---
 Flash | byte code | Yes | No | Games, Mobile | alpha (2005)
@@ -15,3 +16,9 @@ Java | source | Yes | Yes | CLI, Mobile, Desktop | 2.10 (2012)
 C# | source | Yes | Yes | Mobile, Desktop | 2.10 (2012)
 Python | source | No | Yes | CLI, Web, Desktop | 3.2 (2015)
 Lua | source | No | Yes | Games, CLI, Web, Desktop | 3.3 (2016)
+
+
+Note:
+- "Static typing: Yes" means the target platform natively supports static typing.
+  Haxe code itself is statically typed no matter what target it is compiled to.
+- "Sys: Yes" means the target supports the [System api](http://api.haxe.org/Sys.html).


### PR DESCRIPTION
As a newcomer, you might think typing is not always available when quickly looking at this table.