### PR TITLE
Remove unnecessary sections

### DIFF
--- a/pages/download/linux/index.html
+++ b/pages/download/linux/index.html
@@ -25,7 +25,7 @@ mkdir ~/haxelib &amp;&amp; haxelib setup ~/haxelib</pre>
 <p>Neko will be installed as a dependency of Haxe.</p>
 <p>To install the newer ones from the unstable channel, follow these steps:</p>
 <ol>
-	<li>In <b>/etc/apt/sources.list</b>, add <pre>deb http://httpredir.debian.org/debian unstable main contrib non-free</pre></li>
+	<li>In <b>/etc/apt/sources.list</b>, add <pre>deb http://httpredir.debian.org/debian unstable main</pre></li>
 	<li>
 		In <b>/etc/apt/preferences.d/</b>, create a new file named <b>unstable</b> (the name can be anything) with the content as follows:<pre>Package: *
 Pin: release a=unstable


### PR DESCRIPTION
The debian install guide tells the user to add the following line

    deb http://httpredir.debian.org/debian unstable main contrib non-free

to `/etc/apt/sources.list`

`contrib` and `non-free` are as far as I know not necessary for haxe to work, besides not being opensource.