### PR TITLE
Fixes search and haxe logo in navbar being unclickable at certain sizes

### DIFF
--- a/www/css/haxe-nav.css
+++ b/www/css/haxe-nav.css
@@ -93,7 +93,7 @@ nav .navbar .nav>li>.dropdown-menu:after {
 
 /** SUB BRAND LOGOS **/
 
-.navbar .brand.haxe-logo { padding-right:0; margin: 3px 0 0 0px; }
+.navbar .brand.haxe-logo { padding-right:0; margin: 3px 0 0 0px; position: relative; z-index: 100; }
 .navbar .brand.haxe-logo:hover { opacity:.9; }
 
 .navbar .brand.haxe-logo:after {
@@ -152,4 +152,8 @@ nav .navbar .nav>li>.dropdown-menu:after {
 }
 .navbar .brand.sub.ide:before {
 	color:#f89c0e;
+}
+
+.navbar .search-link-menu {
+	z-index: 100;
 }


### PR DESCRIPTION
How to reproduce : 
1. go to haxe.org
2. resize the window size to anything above 980 width
3. try to click the haxe logo in top left corner

Search bar is _sometimes_ not clickable when the width is around ~1200px.

The css z-index changes in this PR fix this.