### PR TITLE
reduce number of codeclimate issues

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@ engines:
   haxe-checkstyle:
     enabled: true
   csslint:
-    enabled: true
+    enabled: false
   markdownlint:
-    enabled: true
+    enabled: false
 
 exclude_paths:
   - manual/**/*

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = false
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -2,7 +2,16 @@
 	"defineCombinations": [],
 	"defaultSeverity": "INFO",
 	"baseDefines": [],
-	"exclude": {},
+	"exclude": {
+		"MemberName": [
+			"DownloadsData:GithubUser",
+			"DownloadsData:GithubAsset",
+			"DownloadsData:GithubRelease"
+		],
+		"MethodName": [
+			"Views"
+		]
+    },
 	"checks": [
 		{
 			"props": {},
@@ -205,7 +214,7 @@
 				"tokens": [
 					"PUBLIC",
 					"PRIVATE",
-					"STATIIC",
+					"STATIC",
 					"NOTSTATIC",
 					"INLINE",
 					"NOTINLINE"


### PR DESCRIPTION
- disable markdownlint 
  more than 3400 issues; complaining about line length, header style, trailing whitespace, etc.
  Unless someone volunteers, these issues will remain indefinitely.
  Alternative approach would be to disable individual markdownlint checks, though it's unclear how many checks would remain active.
- disable csslint
  more than 1500 issues; most of them from external files like `bootstrap.min.css`
  It's unlikely that external files will ever pass a csslint check, unless their owners make an effort to do so. 
  Which leaves over 400 issues in `style.css`, waiting for a volunteer...
- added editorconfig file
  should help with trailing whitespace and indentation character issues for future edits (when using an editor with editorconfig support)
- added some excludes to checkstyle
  not sure if `checkstyle.json` represents the "official" coding style, there seem to be a lot of different styles (sometimes conflicting) mixed together (e.g. using `checkstyle.json` on haxelib's sources produces over 4000 issues).
  Fixing remaining issues requires some manual work and refactoring (or disabling individual checks or making them less strict).
