### PR TITLE
Add the ACCU 2019 talk to the videos section

### DIFF
--- a/videos/conferences/10.accu-2019.json
+++ b/videos/conferences/10.accu-2019.json
@@ -1,0 +1,12 @@
+{
+	"title": "ACCU 2019",
+	"description": "Conference held by ACCU, a non-profit user group of people interested in software development.",
+	"videos": [{
+			"title": "Haxe: An understated powerhouse for software development - George Corney",
+			"where": null,
+			"description": "<p>Haxe is a strictly-typed (and type-inferring) programming language with a diverse set of influences, including OCaml, Java and ActionScript. Its syntax will be familiar to anyone who’s worked with modern OO languages, however it has features you’d expect in a meta language, such as: everything’s-an-expression, compile-time code manipulation and pattern matching. In addition, it boasts an unusual talent; it can generate code in other programming languages.</p><p>In this talk I discuss the language’s killer features (and how I use them in GPU programming work), I explain the benefits of blending your static data with your code via haxe’s compile-time code generation, and I aim answer questions including:</p><ul><li><p>What is haxe useful for?</p></li><li><p>Who’s using it?</p></li><li><p>What are the drawbacks and weaknesses?</p></li></ul>",
+			"date": "2019-04-13",
+			"featured": true,
+			"youtubeId": "TbhkHrcslrE"
+		}]
+}

--- a/videos/conferences/8.haxeup-session-jan-2019-luxembourg.json
+++ b/videos/conferences/8.haxeup-session-jan-2019-luxembourg.json
@@ -4,7 +4,7 @@
 	"videos": [
     {
       "title": "Navigating the Haxe community - Josefiene Pertosa",
-      "where": "HaxeUp Sessions Januari 2019, Luxembourg",
+      "where": "HaxeUp Sessions January 2019, Luxembourg",
       "description": "Navigating the Haxe community, when it isn\u2019t in the manual<br\/><br\/>Community Cheat Sheet<br\/>- Github: <a href='https:\/\/github.com\/haxefoundation'>https:\/\/github.com\/haxefoundation<\/a><br\/>- The Forum: <a href='https:\/\/community.haxe.org\/'>https:\/\/community.haxe.org\/<\/a><br\/>- Haxe Roundup: <a href='https:\/\/haxe.io\/'>https:\/\/haxe.io\/<\/a><br\/>- Twitter: #haxe<br\/>- Discord: <a href='https:\/\/discordapp.com\/invite\/0uEuWH3spjck73Lo'>https:\/\/discordapp.com\/invite\/0uEuWH3spjck73Lo<\/a><br\/>- Gitter Chat: <a href='https:\/\/gitter.im\/HaxeFoundation'>https:\/\/gitter.im\/HaxeFoundation\/<\/a><br\/>- Stackoverflow: <a href='https:\/\/stackoverflow.com\/questions\/tagged\/haxe'>https:\/\/stackoverflow.com\/questions\/tagged\/haxe<\/a><br\/>- Subreddit: <a href='https:\/\/www.reddit.com\/r\/haxe'>https:\/\/www.reddit.com\/r\/haxe<\/a>",
       "date": "2019-01-29",
       "youtubeId": "O3s9mSbs1hk",
@@ -12,7 +12,7 @@
     },
     {
       "title": "Demystifying Haxe to JavaScript - Philippe Elsass",
-      "where": "HaxeUp Sessions Januari 2019, Luxembourg",
+      "where": "HaxeUp Sessions January 2019, Luxembourg",
       "description": "Demystifying Haxe to JavaScript: Compilation, interop and bundling",
       "date": "2019-01-29",
       "youtubeId": "pmnJ3JE4hNw",
@@ -20,7 +20,7 @@
     },
     {
       "title": "What the Haxe! - Juraj Kircheim",
-      "where": "HaxeUp Sessions Januari 2019, Luxembourg",
+      "where": "HaxeUp Sessions January 2019, Luxembourg",
       "description": "",
       "date": "2019-01-29",
       "youtubeId": "gsq1YeJOotE",
@@ -28,7 +28,7 @@
     },
     {
       "title": "Next Level Type Safety - Dan Korostelev",
-      "where": "HaxeUp Sessions Januari 2019, Luxembourg",
+      "where": "HaxeUp Sessions January 2019, Luxembourg",
       "description": "Links: <br\/><a href='https:\/\/github.com\/HeapsIO\/heaps'>https:\/\/github.com\/HeapsIO\/heaps\/<\/a> (see hxsl and hxd.res)<br\/><a href='https:\/\/github.com\/ncannasse\/hxbit'>https:\/\/github.com\/ncannasse\/hxbit<\/a><br\/><a href='https:\/\/github.com\/ncannasse\/castle'>https:\/\/github.com\/ncannasse\/castle<\/a> (see cdb)<br\/><a href='https:\/\/github.com\/haxetink\/tink_json'>https:\/\/github.com\/haxetink\/tink_json<\/a><br\/><a href='https:\/\/github.com\/haxetink\/tink_sql'>https:\/\/github.com\/haxetink\/tink_sql<\/a><br\/><a href='https:\/\/github.com\/haxetink\/tink_template'>https:\/\/github.com\/haxetink\/tink_template<\/a><br\/><a href='https:\/\/github.com\/Simn\/hxargs'>https:\/\/github.com\/Simn\/hxargs<\/a><br\/><a href='https:\/\/github.com\/nadako\/stiletto'>https:\/\/github.com\/nadako\/stiletto<\/a><br\/><a href='https:\/\/github.com\/nadako\/hxlocalize'>https:\/\/github.com\/nadako\/hxlocalize<\/a>",
       "date": "2019-01-29",
       "youtubeId": "i6yOT69rSc0",
@@ -36,7 +36,7 @@
     },
     {
       "title": "DOMkit - Macro based UI components - Nicolas Cannasse",
-      "where": "HaxeUp Sessions Januari 2019, Luxembourg",
+      "where": "HaxeUp Sessions January 2019, Luxembourg",
       "description": "DOMkit: strictly typed macro based UI components framework<br\/><br\/><a href='https:\/\/github.com\/ncannasse\/domkit\/'>https:\/\/github.com\/ncannasse\/domkit\/<\/a><br\/>Heaps samples: <a href='https:\/\/github.com\/HeapsIO\/heaps\/blob\/master\/samples\/Domkit.hx'>https:\/\/github.com\/HeapsIO\/heaps\/blob\/master\/samples\/Domkit.hx<\/a>",
       "date": "2019-01-29",
       "youtubeId": "nQVx56cqOeQ",


### PR DESCRIPTION
The only part that's perhaps a bit strange is that this is now listed under "Haxe conferences", when it's really just a non-Haxe-conference that happens to have had a talk about Haxe.

Not sure if that warrants creating a whole new category though... Or maybe "Haxe Conferences" could just be changed to "Conferences".