### PR TITLE
Fix CI on pull requests

### DIFF
--- a/src/DownloadsData.hx
+++ b/src/DownloadsData.hx
@@ -135,7 +135,8 @@ class DownloadsData {
 		if (githubRelease != null) {
 			downloadUrls = githubRelease.assets.map(function(a) return a.browser_download_url);
 		} else {
-			if (Sys.getEnv("TRAVIS_PULL_REQUEST") != "false") {
+			var prEnv = Sys.getEnv("TRAVIS_PULL_REQUEST");
+			if (prEnv != null && prEnv != "false") {
 				trace('Warning: failed to retrieve download links for version ${version.tag}; skipping assets for this build.');
 			} else {
 				throw 'missing github release for version ${version.tag}';

--- a/src/DownloadsData.hx
+++ b/src/DownloadsData.hx
@@ -113,7 +113,8 @@ class DownloadsData {
 		var releases:Array<GithubRelease> = Json.parse(data.stdout.readAll().toString());
 		data.close();
 		#end
-		releases;
+		// Github API will return an object instead when there is an error (rate limit, etc.)
+		Std.is(releases, Array) ? releases : [];
 	}
 
 	static function getDownloadInfo (version:Version) {
@@ -127,10 +128,19 @@ class DownloadsData {
 		function getInfo (title:String, url:String) : Download {
 			return { title: title, url:url, filename: Path.withoutDirectory(url) };
 		}
+
+		var downloadUrls = [];
 		var githubRelease = githubReleases.find(function(r) return r.tag_name == version.tag);
-		if (githubRelease == null)
-			throw 'missing github release for version ${version.tag}';
-		var downloadUrls = githubRelease.assets.map(function(a) return a.browser_download_url);
+
+		if (githubRelease != null) {
+			downloadUrls = githubRelease.assets.map(function(a) return a.browser_download_url);
+		} else {
+			if (Sys.getEnv("TRAVIS_PULL_REQUEST") != "false") {
+				trace('Warning: failed to retrieve download links; skipping assets for this build.');
+			} else {
+				throw 'missing github release for version ${version.tag}';
+			}
+		}
 
 		//TODO: make something a little less horrible here
 		for (url in downloadUrls) {

--- a/src/DownloadsData.hx
+++ b/src/DownloadsData.hx
@@ -136,7 +136,7 @@ class DownloadsData {
 			downloadUrls = githubRelease.assets.map(function(a) return a.browser_download_url);
 		} else {
 			if (Sys.getEnv("TRAVIS_PULL_REQUEST") != "false") {
-				trace('Warning: failed to retrieve download links; skipping assets for this build.');
+				trace('Warning: failed to retrieve download links for version ${version.tag}; skipping assets for this build.');
 			} else {
 				throw 'missing github release for version ${version.tag}';
 			}


### PR DESCRIPTION
On pull requests, we call github API without a token and quickly get a rate limit error.

When that happens, we get an error object instead of an array of github releases, which is not catched by the code and breaks almost every CI runs on PRs.

This PR does two things:
* detect failed github API calls and fallback to `[]` for github releases
* when on a PR, trace a warning and fallback to an empty assets (download links) array instead of crashing

Example job hitting github API rate limit and not failing: https://travis-ci.org/HaxeFoundation/haxe.org/jobs/534270733

Note on the PR detection, from [travis docs](https://docs.travis-ci.com/user/environment-variables/):
>`TRAVIS_PULL_REQUEST` is set to the pull request number if the current job is a pull request build, or `false` if it’s not.