### PR TITLE
Improvements to platform introductions

### DIFF
--- a/pages/documentation/introduction/index.html
+++ b/pages/documentation/introduction/index.html
@@ -9,8 +9,8 @@
 		</div>
 		<p>Basic introduction to the Haxe language, the compiler, the standard library and anything else you need to get started.</p>
 		<p>
-			&raquo; <a href="/documentation/introduction/toolkit-introduction.html">Toolkit introduction</a><br />
-			&raquo; <a href="/documentation/introduction/editors-and-ides.html">Editors and IDEs</a><br />
+			&raquo; <a href="/documentation/introduction/toolkit-introduction.html">Toolkit introduction</a><br/>
+			&raquo; <a href="/documentation/introduction/editors-and-ides.html">Editors and IDEs</a><br/>
 			&raquo; <a href="/documentation/introduction/building-haxe.html">Building from source</a>
 		</p>
 	</div>
@@ -20,7 +20,7 @@
 		</div>
 		<p>A comprehensive manual for Haxe 3.  (This assumes a familiarity with general programming concepts, it is not a beginner's tutorial.)</p>
 		<p>
-			&raquo; <a href="/manual/introduction.html">Haxe Manual</a><br />		
+			&raquo; <a href="/manual/introduction.html">Haxe Manual</a><br/>		
 			&raquo; <a href="/manual/introduction-about-this-document.html">About the manual</a>
 		</p>
 	</div>
@@ -30,7 +30,7 @@
 		</div>
 		<p>Complete API documentation for the <a href="/documentation/introduction/stdlib-introduction.html">Haxe 3 Standard Library</a>.</p>
 		<p>
-			&raquo; <a href="/api/">API Documentation</a><br />
+			&raquo; <a href="/api/">API Documentation</a><br/>
 			&raquo; <a href="https://github.com/HaxeFoundation/haxe/releases/download/3.4.3/api-3.4.3.zip">Offline API Documentation (Zip)</a>
 		</p>
 	</div>

--- a/pages/documentation/platforms/csharp.html
+++ b/pages/documentation/platforms/csharp.html
@@ -85,7 +85,7 @@
 	<div class="step-info">
 		<h4>Visual Studio Compiler</h4>
 		<p>
-			1. If you want to use Visual Studio to compile and debug your project, you can disable the automatic compilation and simply use Haxe to generate the <code>.cs</code> files.<br/>
+			1. If you want to use Visual Studio to compile and debug your project, you can disable the automatic compilation and simply use Haxe to generate the <code>.cs</code> files.
 			To do this, add <code>-D no-compilation -D real-position</code> to the end of your <code>.hxml</code> file.<br/>
 			2. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 			3. Install <a href="https://visualstudio.microsoft.com/downloads/">Visual Studio Community Edition</a>.<br/>
@@ -137,8 +137,8 @@ System.dll</pre>
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			You can use <a href="https://api.haxe.org/cs/">C# platform specific API</a> in addition to the core Haxe API.<br/>
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project, which replaces all <code>System.*</code> classes that you would typically use in a C# project.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/cs/">C#-specific APIs</a> in addition to the core Haxe APIs.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
@@ -148,7 +148,7 @@ System.dll</pre>
 		</p>
 		<h4>Third-party DLLs and assemblies</h4>
 		<p>
-			Refer to <a href="/manual/target-cs-external-libraries.html">this guide</a> to add third-party DLLs and assemblies.<br/>
+			Refer to <a href="/manual/target-cs-external-libraries.html">this guide</a> to add third-party DLLs and assemblies.
 			If you use VS Code, the Haxe extension will find these dependencies and enable IntelliSense (code completion) for their classes and objects.<br/>
 		</p>
 	</div>

--- a/pages/documentation/platforms/csharp.html
+++ b/pages/documentation/platforms/csharp.html
@@ -80,36 +80,35 @@
 		4
 	</div>
 	<h2 class="step-title">
-		Compile and run your project
+		Install a C# compiler
 	</h2>
 	<div class="step-info">
 		<h4>Visual Studio Compiler</h4>
 		<p>
-			1. If you want to use Visual Studio to compile and debug your project, you can disable the automatic compilation and simply ask Haxe to generate the <code>.cs</code> codefiles. <br/>
-			To do this, add <code>-D no-compilation real-position</code> to the end of your <code>.hxml</code> file. <br/>
-			2. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
-			3. Install <a href="https://visualstudio.microsoft.com/downloads/">Visual Studio Community Edition</a> if you don't already have VS installed. <br/>
-			4. Open the <code>bin/cs/Main.csproj</code> C# project in Visual Studio. If you are prompted about the .NET Framework version being unsupported, select the option to "Change the target to .NET Framework...". <br/>
-			5. Open up the <code>.cs</code> that corresponds to the <code>.hx</code> file that you want to debug, for example <code>Main.cs</code> for the Main class file. <br/>
-			6. Add breakpoints into your C# code as you wish and Start Debugging your project (press F5). <br/>
+			1. If you want to use Visual Studio to compile and debug your project, you can disable the automatic compilation and simply use Haxe to generate the <code>.cs</code> files.<br/>
+			To do this, add <code>-D no-compilation -D real-position</code> to the end of your <code>.hxml</code> file.<br/>
+			2. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
+			3. Install <a href="https://visualstudio.microsoft.com/downloads/">Visual Studio Community Edition</a>.<br/>
+			4. Open the <code>bin/cs/Main.csproj</code> C# project in Visual Studio. If you are prompted about the .NET Framework version being unsupported, select the option to "Change the target to .NET Framework...".<br/>
+			5. Open the <code>.cs</code> file that corresponds to the <code>.hx</code> file that you want to debug, for example <code>Main.cs</code> for the <code>Main</code> class.<br/>
+			6. Add breakpoints into your C# code as you wish and Start Debugging your project (press F5).<br/>
 			7. Visual Studio should compile the project and enter debugging mode, allowing you to easily fix problems in your Haxe code.
 		</p>
 		<h4>.NET Framework Compiler</h4>
 		<p>
-			1. Install the latest <a href="https://dotnet.microsoft.com/download">.NET Framework Dev Pack</a> <br/>
-			2. Install the latest <a href="https://dotnet.microsoft.com/download">.NET Framework Runtime</a> <br/>
-			3. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
+			1. Install the latest <a href="https://dotnet.microsoft.com/download">.NET Framework Dev Pack</a> and the <a href="https://dotnet.microsoft.com/download">.NET Framework Runtime</a>.<br/>
+			3. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 		</p>
 		<h4>Mono Compiler</h4>
 		<p>
-			1. Install the latest <a href="https://www.mono-project.com/download/stable/">Mono Compiler</a> <br/>
-			2. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
+			1. Install the latest <a href="https://www.mono-project.com/download/stable/">Mono Compiler</a><br/>
+			2. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 		</p>
 		<h4>.NET Core Compiler <span>BETA</span></h4>
 		<p>
-			1. Install the latest <a href="https://dotnet.microsoft.com/download">.NET Core SDK</a> and the <a href="https://dotnet.microsoft.com/download">.NET Core Runtime</a> <br/>
-			2. If on Windows, add the environment variable <code>MSBuildSDKsPath</code> with the value of your SDK directory path (typically <code>C:\Program Files\dotnet\</code> or <code>C:\Program Files (x86)\dotnet\</code>) <br/>
-			3. If on Windows, update the environment variable <code>PATH</code> with the same value<br/>
+			1. Install the latest <a href="https://dotnet.microsoft.com/download">.NET Core SDK</a> and the <a href="https://dotnet.microsoft.com/download">.NET Core Runtime</a>.<br/>
+			2. If on Windows, add the environment variable <code>MSBuildSDKsPath</code> with the value of your SDK directory path (typically <code>C:\Program Files\dotnet\</code> or <code>C:\Program Files (x86)\dotnet\</code>).<br/>
+			3. If on Windows, update the environment variable <code>PATH</code> with the same value.<br/>
 			4. Add the following into your <code>.hxml</code> file:
 		</p>
 			<pre class="step-code">--net-std ./netstd
@@ -122,7 +121,7 @@
 System.Core.dll
 System.dll</pre>
 		<p>
-			6. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
+			6. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 			7. Compile and run your app with the <code>dotnet</code> or <code>dotnet.exe</code> CLI.
 		</p>
 	</div>
@@ -138,19 +137,19 @@ System.dll</pre>
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			You can use <a href="https://api.haxe.org/cs/">C# platform specific API</a> in addition to the core Haxe API. <br/>
+			You can use <a href="https://api.haxe.org/cs/">C# platform specific API</a> in addition to the core Haxe API.<br/>
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project, which replaces all <code>System.*</code> classes that you would typically use in a C# project.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
-			Browse the <a href="https://lib.haxe.org/t/cs/">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			Browse the <a href="https://lib.haxe.org/t/cs/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to your <code>.hxml</code> file.
 		</p>
 		<h4>Third-party DLLs and assemblies</h4>
 		<p>
-			Refer to <a href="/manual/target-cs-external-libraries.html">this guide</a> to add third-party DLLs and assemblies. <br/>
-			If you use VS Code, the Haxe extension will find these dependencies and enable IntelliSense (code completion) for their classes and objects. <br/>
+			Refer to <a href="/manual/target-cs-external-libraries.html">this guide</a> to add third-party DLLs and assemblies.<br/>
+			If you use VS Code, the Haxe extension will find these dependencies and enable IntelliSense (code completion) for their classes and objects.<br/>
 		</p>
 	</div>
 </div>

--- a/pages/documentation/platforms/csharp.html
+++ b/pages/documentation/platforms/csharp.html
@@ -13,11 +13,9 @@
 		Install Haxe
 	</h2>
 	<div class="step-info">
-		1. Download and install the <a href="/download">Haxe Compiler</a>. <br/>
-		2. Run this command in your console to globally install C# support in Haxe.
-		<div class="step-code">
-haxelib install hxcs
-		</div>
+		1. Download and install the <a href="/download">Haxe Compiler</a>.<br/>
+		2. Run this command in your console to globally install C# support in Haxe:
+		<pre class="step-code">haxelib install hxcs</pre>
 	</div>
 </div>
 
@@ -26,7 +24,7 @@ haxelib install hxcs
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
@@ -55,28 +53,25 @@ haxelib install hxcs
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<div class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-    └---cs
-		</div>
-		2. Insert the following code into the <code>Main.hx</code> file:<br/>
+├── bin/
+│   └── cs/
+│
+└── build.hxml</pre>
+		2. Add the following code into the <code>src/Main.hx</code> file:<br/>
 		<pre><code class="prettyprint haxe">class Main {
-  static public function main():Void {
-    trace("Hello World");
+  static function main() {
+    Sys.println("Haxe is great!");
   }
 }</code></pre>
-		3. Create a <code>build.hxml</code> file in your project directory to store compiler configuration <br/>
-		4. Add the following into the file:  <br/>
-		<div class="step-code">
--cp src
+		3. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-cp src
 -main Main
--cs bin/cs
-		</div>
-		The configuration above specifies that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the C# source code in <code>/bin/cs</code>. After code generation, Haxe will automatically detect the installed C#/Mono compiler and use it to compile your project into <code>/bin</code>.
+-cs bin/cs</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the C# source code into <code>bin/cs/</code>. After code generation, Haxe will automatically detect the installed C#/Mono compiler and use it to compile your project into <code>bin/cs/bin/</code>.
 	</div>
 </div>
 
@@ -116,17 +111,17 @@ project
 			2. If on Windows, add the environment variable <code>MSBuildSDKsPath</code> with the value of your SDK directory path (typically <code>C:\Program Files\dotnet\</code> or <code>C:\Program Files (x86)\dotnet\</code>) <br/>
 			3. If on Windows, update the environment variable <code>PATH</code> with the same value<br/>
 			4. Add the following into your <code>.hxml</code> file:
-			<div class="step-code">
---net-std ./netstd
+		</p>
+			<pre class="step-code">--net-std ./netstd
 -D net-ver=47
--D net-target=net
-			</div>
+-D net-target=net</pre>
+		<p>
 			5. Add the following files into the <code>net-std</code> directory, that must be created in your project directory:
-			<div class="step-code">
-mscorlib.dll
+		</p>
+			<pre class="step-code">mscorlib.dll
 System.Core.dll
-System.dll
-			</div>
+System.dll</pre>
+		<p>
 			6. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
 			7. Compile and run your app with the <code>dotnet</code> or <code>dotnet.exe</code> CLI.
 		</p>

--- a/pages/documentation/platforms/java.html
+++ b/pages/documentation/platforms/java.html
@@ -114,8 +114,8 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/java/index.html">Haxe Java API website</a> for the Java-specific API available.<br/>
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/java/">Java-specific APIs</a> in addition to the core Haxe APIs.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
@@ -136,7 +136,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
 	<div class="step-info">
 		<h4>Compilation</h4>
 		<p>
-			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
+			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.
 			This compiles your <code>.hx</code> source code into a Java program which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>

--- a/pages/documentation/platforms/java.html
+++ b/pages/documentation/platforms/java.html
@@ -80,25 +80,27 @@
 		4
 	</div>
 	<h2 class="step-title">
-		Install the Java runtime
+		Install the Java runtime and SDK
 	</h2>
 	<div class="step-info">
-		Haxe requires Java 6. Due to security fixes and new features Java 8 or later is recommended. <br/><br/>
+		Haxe requires Java 6 or later. Due to security fixes and new features Java 8 or later is recommended.<br/><br/>
 		
-		1. Install the latest Java Runtime Environment (JRE) and Software Development Kit (SDK).
+		1. Install the latest Java Runtime Environment (JRE).
+		2. Test your installation by opening a command prompt and typing <code>java -showversion</code>.
 		<ul>
-			<li>The Java SDK is required for development as Haxe can only output Java source code, not the final <code>.jar</code> file</li>
-			<li>The Java SDK includes the <code>javac</code> compiler that converts <code>.java</code> sources into a <code>.jar</code> file</li>
-			<li>Android Studio would be recommended if targeting mobile platforms, and it comes with its own JRE and JDK installed.</li>
-		</ul>
-		2. Test your installation by opening a command prompt and typing "java -showversion".
-		<ul>
-			<li>If your console cannot find <code>java</code>, you have an issue with your installation or the JRE is not added into the PATH environment variable.</li>
-			<li>You should see something like the following snippet.</li>
+			<li>If your console cannot find <code>java</code>, you have an issue with your installation or the JRE is not added into the <code>PATH</code> environment variable.</li>
+			<li>If the installation was successful, you should see something like the following:</li>
 		</ul>
 		<pre class="step-code">java version "1.8.0_201"
 Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
 Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
+		3. (Optional in Haxe 4) Install the Java Software Development Kit (SDK).
+		<ul>
+			<li>The Java SDK is required for development in Haxe 3, since it can only output Java source code, not the final <code>.jar</code> file.</li>
+			<li>The Java SDK includes the <code>javac</code> compiler that converts <code>.java</code> sources into a <code>.jar</code> file.</li>
+			<li>Since Haxe 4, the Java source code step can be skipped entirely by using the <code>-D jvm</code> define to output <code>.jar</code> files directly.</li>
+		</ul>
+		4. (Optional) If you are intending to develop mobile applications for Android, install the SDK of the target Android version.
 	</div>
 </div>
 
@@ -112,13 +114,13 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/java/index.html">Haxe Java API website</a> for the Java-specific API available. <br/>
+			Browse the <a href="https://api.haxe.org/java/index.html">Haxe Java API website</a> for the Java-specific API available.<br/>
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
-			Browse the <a href="https://lib.haxe.org/t/java/">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			Browse the <a href="https://lib.haxe.org/t/java/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to your <code>.hxml</code> file.
 		</p>
 	</div>
@@ -134,12 +136,12 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
 	<div class="step-info">
 		<h4>Compilation</h4>
 		<p>
-			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
+			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 			This compiles your <code>.hx</code> source code into a Java program which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>
 		<p>
-			After compiling your project with Haxe and Java, you'll need to open a console in the <code>bin/java</code> directory and run the command <code>java -jar Main.jar</code> <br/>
+			After compiling your project with Haxe and Java, you'll need to open a console in the <code>bin/java</code> directory and run the command <code>java -jar Main.jar</code><br/>
 			You can alternatively use a full-fledged Java IDE like the ones given below to run and debug your project easily.
 		</p>
 		<h4>Install a Java IDE</h4>

--- a/pages/documentation/platforms/java.html
+++ b/pages/documentation/platforms/java.html
@@ -13,11 +13,9 @@
 		Install Haxe
 	</h2>
 	<div class="step-info">
-		1. Download and install the <a href="/download">Haxe Compiler</a>. <br/>
-		2. Run this command in your console to globally install Java support in Haxe.
-		<div class="step-code">
-haxelib install hxjava
-		</div>
+		1. Download and install the <a href="/download">Haxe Compiler</a>.<br/>
+		2. Run this command in your console to globally install Java support in Haxe:
+		<pre class="step-code">haxelib install hxjava</pre>
 	</div>
 </div>
 
@@ -26,19 +24,19 @@ haxelib install hxjava
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible Haxe IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
 		<ul>
-			<li><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>
-				<ul>
-					<li>Install the <a href="https://plugins.jetbrains.com/plugin/6873?pr=idea">Haxe Plugin</a></li>
-				</ul>
-			</li>
 			<li><a href="https://code.visualstudio.com/">Visual Studio Code</a>
 				<ul>
 					<li>Install the <a href="https://marketplace.visualstudio.com/items?itemName=vshaxe.haxe-extension-pack">Haxe Extension Pack</a></li>
+				</ul>
+			</li>
+			<li><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>
+				<ul>
+					<li>Install the <a href="https://plugins.jetbrains.com/plugin/6873?pr=idea">Haxe Plugin</a></li>
 				</ul>
 			</li>
 			<li><a href="/documentation/introduction/editors-and-ides.html">Other IDEs</a></li>
@@ -55,28 +53,25 @@ haxelib install hxjava
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<div class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-    └---java
-		</div>
-		2. Insert the following code into the <code>Main.hx</code> file:<br/>
+├── bin/
+│   └── java/
+│
+└── build.hxml</pre>
+		2. Add the following code into the <code>src/Main.hx</code> file:<br/>
 		<pre><code class="prettyprint haxe">class Main {
   static function main() {
-    Lib.println('Haxe is great!');
+    Sys.println("Haxe is great!");
   }
 }</code></pre>
-		3. Create a <code>build.hxml</code> file in your project directory to store compiler configuration <br/>
-		4. Add the following into the file:  <br/>
-		<div class="step-code">
--cp src
+		3. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-cp src
 -main Main
--java bin/java
-		</div>
-		The configuration above specifies that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the Java source code into the <code>bin/java</code> directory. After code generation, Haxe will try <code>javac</code> to compile the generated Java program into a <code>.jar</code> file. You can debug this Java program using a specialized Java IDE. <br/>
+-java bin/java</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the Java source code into <code>bin/java/</code>. After code generation, Haxe will automatically detect the installed Java compiler and use it to compile your project into a JAR file in <code>bin/java/</code>.
 	</div>
 </div>
 
@@ -101,11 +96,9 @@ project
 			<li>If your console cannot find <code>java</code>, you have an issue with your installation or the JRE is not added into the PATH environment variable.</li>
 			<li>You should see something like the following snippet.</li>
 		</ul>
-		<div class="step-code">
-java version "1.8.0_201"
+		<pre class="step-code">java version "1.8.0_201"
 Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
-Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)
-		</div>
+Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)</pre>
 	</div>
 </div>
 

--- a/pages/documentation/platforms/javascript.html
+++ b/pages/documentation/platforms/javascript.html
@@ -95,13 +95,13 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available. <br/>
+			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available.<br/>
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
-			Browse the <a href="https://lib.haxe.org/t/javascript/">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			Browse the <a href="https://lib.haxe.org/t/javascript/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to the <code>build.hxml</code> file.
 		</p>
 	</div>
@@ -117,7 +117,7 @@
 	<div class="step-info">
 		<h4>Compilation</h4>
 		<p>
-			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory. <br/>
+			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory.<br/>
 			This compiles your <code>.hx</code> source code to JavaScript which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>

--- a/pages/documentation/platforms/javascript.html
+++ b/pages/documentation/platforms/javascript.html
@@ -22,7 +22,7 @@
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible Haxe IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
@@ -51,25 +51,23 @@
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<pre class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-    └---index.html
-		</pre>
+├── bin/
+│   └── js/
+│       └── index.html
+│
+└── build.hxml</pre>
 		2. Insert the following code into the <code>src/Main.hx</code> file:<br/>
-		<pre class="step-code">
-class Main {
+		<pre><code class="prettyprint haxe">class Main {
   static function main() {
-    trace('Haxe is great!');
+    trace("Haxe is great!");
   }
-}
-		</pre>
-		3. Insert the following code into the <code>bin/index.html</code> file:<br/>
-		<pre class="step-code">
-&lt;!DOCTYPE html>
+}</code></pre>
+		3. Insert the following code into the <code>bin/js/index.html</code> file:<br/>
+		<pre><code class="prettyprint xml">&lt;!DOCTYPE html>
 &lt;html lang="en">
 &lt;head>
 	&lt;meta charset="utf-8">
@@ -78,14 +76,12 @@ class Main {
 &lt;body>
 	&lt;script src="main.js">&lt;/script>
 &lt;/body>
-&lt;/html>	</pre>
-		4. Create a <code>build.hxml</code> file in your project directory to store compiler configuration.  Add the following into the file:  <br/>
-		<pre class="step-code">
--cp src
+&lt;/html></code></pre>
+		4. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-cp src
 -main Main
--js bin/main.js
-		</pre>
-		The configuration above specifies that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the JavaScript source code into <code>bin/main.js</code>.
+-js bin/js/main.js</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the JavaScript source code into <code>bin/js/main.js</code>.
 	</div>
 </div>
 

--- a/pages/documentation/platforms/javascript.html
+++ b/pages/documentation/platforms/javascript.html
@@ -95,8 +95,8 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available.<br/>
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/js/">JavaScript-specific APIs</a> in addition to the core Haxe APIs.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
@@ -118,18 +118,18 @@
 		<h4>Compilation</h4>
 		<p>
 			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory.<br/>
-			This compiles your <code>.hx</code> source code to JavaScript which you can run and debug next.
+			This compiles your <code>.hx</code> source code to JavaScript code which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>
 		<p>
-			After compiling your project with Haxe, you can open and debug the index.html file in your browser. Open your browser devtools console to see the 'Haxe is great!' log message. Beside the build-in <a href="/manual/debugging.html">debugging</a> features you can use the devtools to debug/inspect your application. 
+			After compiling your project with Haxe, you can open and debug the <code>index.html</code> file in your browser. Open the developer tools in the browser to see log output. If you haven't changed the example from step 3, you should see the 'Haxe is great!' log message.
 		</p>
 	</div>
 </div>
 
 <div class="step-item">
 	<div class="step-number">
-		7
+		6
 	</div>
 	<h2 class="step-title">
 		Ask the community

--- a/pages/documentation/platforms/nodejs.html
+++ b/pages/documentation/platforms/nodejs.html
@@ -1,7 +1,7 @@
 <div class="step-item">
 	<h1>
 		<img src="/img/platforms/javascript.png"/>
-		Getting started with Haxe for Node.js
+		Getting started with Haxe for Node.JS
 	</h1>
 </div>
 
@@ -14,7 +14,7 @@
 	</h2>
 	<div class="step-info">
 		1. Download and install the <a href="/download">Haxe Compiler</a>.<br/>
-		2. Run this command in your console to globally install Node.js support in Haxe:
+		2. Run this command in your console to globally install Node.JS support in Haxe:
 		<pre class="step-code">haxelib install hxnodejs</pre>
 	</div>
 </div>
@@ -81,10 +81,10 @@
 		4
 	</div>
 	<h2 class="step-title">
-		Install the Node.js runtime
+		Install the Node.JS runtime
 	</h2>
 	<div class="step-info">
-		1. Install <a href="https://nodejs.org/">Node.js</a>.<br/>
+		1. Install <a href="https://nodejs.org/">Node.JS</a>.<br/>
 		2. Test your installation by opening a command prompt and typing <code>node --version</code>.<br/>
 		<ul>
 			<li>If your console cannot find <code>node</code>, you have an issue with your installation or <code>node</code> is not added into the <code>PATH</code> environment variable.</li>
@@ -104,13 +104,12 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available.<br/> 
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
-			Browse the <a href="http://haxefoundation.github.io/hxnodejs/js/Node.html">Haxe/Node.js API documentation</a> for the available functionality in node.js.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/js/">JavaScript-specific APIs</a> in addition to the core Haxe APIs, as well as <a href="http://haxefoundation.github.io/hxnodejs/js/Node.html">Node.JS-specific APIs</a>.
 		</p>
 		<h4>Haxe libraries</h4>
-			Browse the <a href="https://lib.haxe.org/t/nodejs/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
 		<p>
+			Browse the <a href="https://lib.haxe.org/t/nodejs/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
 			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to the <code>build.hxml</code> file.
 		</p>
@@ -128,11 +127,12 @@
 		<h4>Compilation</h4>
 		<p>
 			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory.<br/>
-			This compiles your <code>.hx</code> source code into Python scripts which you can run and debug next.
+			This compiles your <code>.hx</code> source code into JavaScript code which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>
 		<p>
-			After compiling your project with Haxe, you'll need to open a console in the <code>bin/</code> directory and run the command <code>node main.js</code> and you'll see the 'Haxe is great!' log message. 
+			After compiling your project with Haxe, you'll need to open a console in the <code>bin/js</code> directory and run the command <code>node main.js</code>. If you haven't changed the example from step 3, you should see the 'Haxe is great!' log message.
+			Node.JS provides a <a href="https://nodejs.org/api/debugger.html">built-in debugger</a>. To output a <code>debugger</code> statement, use <code>js.Lib.debug()</code>.
 		</p>
 	</div>
 </div>

--- a/pages/documentation/platforms/nodejs.html
+++ b/pages/documentation/platforms/nodejs.html
@@ -84,7 +84,7 @@
 		Install the Node.js runtime
 	</h2>
 	<div class="step-info">
-		1. Install <a href="https://nodejs.org/">Node.js</a>.<br />
+		1. Install <a href="https://nodejs.org/">Node.js</a>.<br/>
 		2. Test your installation by opening a command prompt and typing <code>node --version</code>.<br/>
 		<ul>
 			<li>If your console cannot find <code>node</code>, you have an issue with your installation or <code>node</code> is not added into the <code>PATH</code> environment variable.</li>
@@ -104,14 +104,14 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available. <br/> 
+			Browse the <a href="https://api.haxe.org/javascript/">Haxe JavaScript API website</a> for the JavaScript-specific API available.<br/> 
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
 			Browse the <a href="http://haxefoundation.github.io/hxnodejs/js/Node.html">Haxe/Node.js API documentation</a> for the available functionality in node.js.
 		</p>
 		<h4>Haxe libraries</h4>
-			Browse the <a href="https://lib.haxe.org/t/nodejs/">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
+			Browse the <a href="https://lib.haxe.org/t/nodejs/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
 		<p>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to the <code>build.hxml</code> file.
 		</p>
 	</div>
@@ -127,7 +127,7 @@
 	<div class="step-info">
 		<h4>Compilation</h4>
 		<p>
-			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory. <br/>
+			Build the Haxe project by running <code>haxe build.hxml</code> in a console in the project directory.<br/>
 			This compiles your <code>.hx</code> source code into Python scripts which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>

--- a/pages/documentation/platforms/nodejs.html
+++ b/pages/documentation/platforms/nodejs.html
@@ -13,7 +13,9 @@
 		Install Haxe
 	</h2>
 	<div class="step-info">
-		Download and install the <a href="/download">Haxe Compiler</a>.
+		1. Download and install the <a href="/download">Haxe Compiler</a>.<br/>
+		2. Run this command in your console to globally install Node.js support in Haxe:
+		<pre class="step-code">haxelib install hxnodejs</pre>
 	</div>
 </div>
 
@@ -22,7 +24,7 @@
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible Haxe IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
@@ -51,35 +53,50 @@
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<pre class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-		</pre>
+├── bin/
+│   └── js/
+│
+└── build.hxml</pre>
 		2. Insert the following code into the <code>src/Main.hx</code> file:<br/>
-		<pre class="step-code">
-class Main {
+		<pre><code class="prettyprint haxe">class Main {
   static function main() {
-    trace('Haxe is great!');
+    Sys.println("Haxe is great!");
   }
-}
-		</pre>
-		3. Create a <code>build.hxml</code> file in your project directory to store compiler configuration.  Add the following into the file:  <br/>
-		<pre class="step-code">
+}</code></pre>
+		3. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-lib hxnodejs
 -cp src
 -main Main
--js bin/main.js
--lib hxnodejs
-		</pre>
-		The configuration above specifies that you are using the <code>hxnodejs</code> haxelib (required for node.js), that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the JavaScript source code into <code>bin/main.js</code>. After code generation, you can run / debug the node.js application. 
+-js bin/js/main.js</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the JavaScript source code into <code>bin/js/main.js</code>.
 	</div>
 </div>
 
 <div class="step-item">
 	<div class="step-number">
 		4
+	</div>
+	<h2 class="step-title">
+		Install the Node.js runtime
+	</h2>
+	<div class="step-info">
+		1. Install <a href="https://nodejs.org/">Node.js</a>.<br />
+		2. Test your installation by opening a command prompt and typing <code>node --version</code>.<br/>
+		<ul>
+			<li>If your console cannot find <code>node</code>, you have an issue with your installation or <code>node</code> is not added into the <code>PATH</code> environment variable.</li>
+			<li>If the installation was successful, you should see something like the following:</li>
+		</ul>
+		<pre class="step-code">v10.16.0</pre>
+	</div>
+</div>
+
+<div class="step-item">
+	<div class="step-number">
+		5
 	</div>
 	<h2 class="step-title">
 		Develop your project

--- a/pages/documentation/platforms/php.html
+++ b/pages/documentation/platforms/php.html
@@ -22,7 +22,7 @@
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
@@ -51,29 +51,25 @@
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<div class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-		</div>
-		2. Insert the following code into the <code>Main.hx</code> file:<br/>
-		<pre><code class="prettyprint haxe">import php.Lib;
-
-class Main {
+├── bin/
+│   └── php/
+│
+└── build.hxml</pre>
+		2. Insert the following code into the <code>src/Main.hx</code> file:<br/>
+		<pre><code class="prettyprint haxe">class Main {
   static function main() {
-    Lib.println('Haxe is great!');
+    Sys.println("Haxe is great!");
   }
 }</code></pre>
-		3. Create a <code>build.hxml</code> file in your project directory to store compiler configuration <br/>
-		4. Add the following into the file:  <br/>
-		<div class="step-code">
--cp src
+		3. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-cp src
 -main Main
--php bin
-		</div>
-		The configuration above specifies that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the PHP source code in <code>/bin</code>.
+-php bin/php</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the PHP source code into <code>bin/php/</code>.
 	</div>
 </div>
 
@@ -132,11 +128,9 @@ class Main {
 			2. Navigate to your webserver's <code>www</code> or <code>htdocs</code> directory and create a sub-directory for your project (for example <code>"myproject"</code>) <br/>
 			3. Enter that directory path in your <code>compile.xml</code> file to have Haxe generate PHP files directly into your webserver's directory.
 		</p>
-		<div class="step-code">
--cp src
+		<pre class="step-code">-cp src
 -main src/Main.hx
--php C:/xampp/htdocs/myproject/
-		</div>
+-php C:/xampp/htdocs/myproject/</pre>
 		<p>
 			4. Start your PHP webserver (if you are using XAMPP, open the control panel and Start the Apache webserver) <br/>
 			5. Navigate to <code>http://localhost/myproject/</code> and you should see the output of your PHP project in your browser
@@ -150,14 +144,11 @@ class Main {
 		<h4>On the Command-line</h4>
 		<p>
 			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
-			2. Open your console and navigate to your Haxe project directory <br/>
-			3. Ensure that your PHP runtime is added to your <a href="https://www.sitepoint.com/how-to-install-php-on-windows/">Environment Variables</a> (For Windows users only) <br/>
-			4. Open your console and navigate to your Haxe project directory <br/>
-			5. Run this command to execute your program with the PHP runtime:
+			2. Ensure that your PHP runtime is added to your <a href="https://www.sitepoint.com/how-to-install-php-on-windows/">Environment Variables</a> (For Windows users only) <br/>
+			3. Open your console and navigate to your Haxe project directory <br/>
+			4. Run this command to execute your program with the PHP runtime:
 		</p>
-		<div class="step-code">
-$ php bin/index.php
-		</div>
+		<pre class="step-code">php bin/index.php</pre>
 	</div>
 </div>
 

--- a/pages/documentation/platforms/php.html
+++ b/pages/documentation/platforms/php.html
@@ -102,13 +102,13 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			You can use <a href="https://api.haxe.org/php/">PHP platform specific API</a> in addition to the core Haxe API. <br/>
+			You can use <a href="https://api.haxe.org/php/">PHP platform specific API</a> in addition to the core Haxe API.<br/>
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project, which replaces some of the PHP methods that you would typically use in a PHP project.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
-			Browse the <a href="https://lib.haxe.org/t/php">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			Browse the <a href="https://lib.haxe.org/t/php">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to your <code>.hxml</code> file.
 		</p>
 	</div>
@@ -124,28 +124,28 @@
 	<div class="step-info">
 		<h4>On a local PHP Runtime</h4>
 		<p>
-			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
-			2. Navigate to your webserver's <code>www</code> or <code>htdocs</code> directory and create a sub-directory for your project (for example <code>"myproject"</code>) <br/>
+			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
+			2. Navigate to your webserver's <code>www</code> or <code>htdocs</code> directory and create a sub-directory for your project (for example <code>"myproject"</code>)<br/>
 			3. Enter that directory path in your <code>compile.xml</code> file to have Haxe generate PHP files directly into your webserver's directory.
 		</p>
 		<pre class="step-code">-cp src
 -main src/Main.hx
 -php C:/xampp/htdocs/myproject/</pre>
 		<p>
-			4. Start your PHP webserver (if you are using XAMPP, open the control panel and Start the Apache webserver) <br/>
+			4. Start your PHP webserver (if you are using XAMPP, open the control panel and Start the Apache webserver)<br/>
 			5. Navigate to <code>http://localhost/myproject/</code> and you should see the output of your PHP project in your browser
 		</p>
 		<h4>On a PHP Web Host</h4>
 		<p>
-			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
-			2. Upload the contents of the <code>/bin</code> folder to your web host's <code>www</code> or <code>htdocs</code> folder. <br/>
+			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
+			2. Upload the contents of the <code>/bin</code> folder to your web host's <code>www</code> or <code>htdocs</code> folder.<br/>
 			3. Navigate to your domain or webserver's IP address in your browser to see the output of your PHP project.
 		</p>
 		<h4>On the Command-line</h4>
 		<p>
-			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
-			2. Ensure that your PHP runtime is added to your <a href="https://www.sitepoint.com/how-to-install-php-on-windows/">Environment Variables</a> (For Windows users only) <br/>
-			3. Open your console and navigate to your Haxe project directory <br/>
+			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
+			2. Ensure that your PHP runtime is added to your <a href="https://www.sitepoint.com/how-to-install-php-on-windows/">Environment Variables</a> (For Windows users only)<br/>
+			3. Open your console and navigate to your Haxe project directory<br/>
 			4. Run this command to execute your program with the PHP runtime:
 		</p>
 		<pre class="step-code">php bin/index.php</pre>

--- a/pages/documentation/platforms/php.html
+++ b/pages/documentation/platforms/php.html
@@ -102,8 +102,8 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			You can use <a href="https://api.haxe.org/php/">PHP platform specific API</a> in addition to the core Haxe API.<br/>
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project, which replaces some of the PHP methods that you would typically use in a PHP project.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/php/">PHP-specific APIs</a> in addition to the core Haxe APIs.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
@@ -122,33 +122,32 @@
 		Compile and run your project
 	</h2>
 	<div class="step-info">
-		<h4>On a local PHP Runtime</h4>
+		<h4>On a local PHP runtime</h4>
 		<p>
 			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
-			2. Navigate to your webserver's <code>www</code> or <code>htdocs</code> directory and create a sub-directory for your project (for example <code>"myproject"</code>)<br/>
-			3. Enter that directory path in your <code>compile.xml</code> file to have Haxe generate PHP files directly into your webserver's directory.
+			2. Navigate to your webserver's <code>www</code> or <code>htdocs</code> directory and create a sub-directory for your project (for example <code>myproject</code>).<br/>
+			3. Enter that directory path in your <code>build.hxml</code> file to have Haxe generate PHP files directly into your webserver's directory.
 		</p>
 		<pre class="step-code">-cp src
 -main src/Main.hx
 -php C:/xampp/htdocs/myproject/</pre>
 		<p>
-			4. Start your PHP webserver (if you are using XAMPP, open the control panel and Start the Apache webserver)<br/>
-			5. Navigate to <code>http://localhost/myproject/</code> and you should see the output of your PHP project in your browser
+			4. Start your PHP webserver (if you are using XAMPP, open the control panel and Start the Apache webserver).<br/>
+			5. Navigate to <code>http://localhost/myproject/</code> and you should see the output of your PHP project in your browser.
 		</p>
-		<h4>On a PHP Web Host</h4>
+		<h4>On a PHP web host</h4>
 		<p>
 			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
-			2. Upload the contents of the <code>/bin</code> folder to your web host's <code>www</code> or <code>htdocs</code> folder.<br/>
+			2. Upload the contents of the <code>bin/php</code> folder to your web host <code>www</code> or <code>htdocs</code> folder.<br/>
 			3. Navigate to your domain or webserver's IP address in your browser to see the output of your PHP project.
 		</p>
-		<h4>On the Command-line</h4>
+		<h4>On the command line</h4>
 		<p>
 			1. Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
-			2. Ensure that your PHP runtime is added to your <a href="https://www.sitepoint.com/how-to-install-php-on-windows/">Environment Variables</a> (For Windows users only)<br/>
 			3. Open your console and navigate to your Haxe project directory<br/>
-			4. Run this command to execute your program with the PHP runtime:
+			2. Run this command to execute your program with the PHP runtime:
 		</p>
-		<pre class="step-code">php bin/index.php</pre>
+		<pre class="step-code">php bin/php/index.php</pre>
 	</div>
 </div>
 

--- a/pages/documentation/platforms/python.html
+++ b/pages/documentation/platforms/python.html
@@ -22,7 +22,7 @@
 		2
 	</div>
 	<h2 class="step-title">
-		Install a compatible Haxe IDE
+		Install a Haxe-compatible IDE
 	</h2>
 	<div class="step-info">
 		It is recommended to install one of these to develop your Haxe projects.
@@ -51,29 +51,25 @@
 	</h2>
 	<div class="step-info">
 		1. Create a new directory for your Haxe project, with this structure:<br/>
-		<div class="step-code">
-project
-└---src
-│   │   Main.hx
+		<pre class="step-code">project/
+├── src/
+│   └── Main.hx
 │
-└---bin
-    └---python
-		</div>
-		2. Insert the following code into the <code>Main.hx</code> file:<br/>
+├── bin/
+│   └── python/
+│
+└── build.hxml</pre>
+		2. Insert the following code into the <code>src/Main.hx</code> file:<br/>
 		<pre><code class="prettyprint haxe">class Main {
   static function main() {
-    Lib.println('Haxe is great!');
+    Sys.println("Haxe is great!");
   }
 }</code></pre>
-		3. Create a <code>build.hxml</code> file in your project directory to store compiler configuration <br/>
-		4. Add the following into the file:  <br/>
-		<div class="step-code">
--lib haxe-strings
--cp src
+		3. Add the following build configuration into the <code>build.hxml</code> file:<br/>
+		<pre class="step-code">-cp src
 -main Main
--python bin/python/main.py
-		</div>
-		The configuration above specifies that you are using the <code>haxe-strings</code> haxelib (totally optional), that your source code is stored in <code>/src</code>, your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the Python script source code into <code>bin/python/main.py</code>. After code generation, you will need to manually run or debug your Python program using a specialized Python IDE.
+-python bin/python/main.py</pre>
+		The configuration above specifies that your source code is stored in <code>src/</code>, that your main Haxe file is <code>src/Main.hx</code>, and that you want Haxe to output the Python source code into <code>bin/python/</code>.
 	</div>
 </div>
 
@@ -98,12 +94,10 @@ project
 			<li>If your console cannot find <code>python</code>, you have an issue with your installation or python is not added into the PATH environment variable.</li>
 			<li>You should see something like the following snippet.</li>
 		</ul>
-		<div class="step-code">
-Python 3.7.2 (tags/v3.7.2:9a3ffc0492, Dec 23 2018, 23:09:28) [MSC v.1916 64 bit
+		<pre class="step-code">Python 3.7.2 (tags/v3.7.2:9a3ffc0492, Dec 23 2018, 23:09:28) [MSC v.1916 64 bit
 (AMD64)] on win32
 Type "help", "copyright", "credits" or "license" for more information.
->>>
-		</div>
+>>></pre>
 		The <code>&gt;&gt;&gt;</code> prompt is from the Python interpreter and shows it is ready to run <code>.py</code> scripts. <br/>
 	</div>
 </div>

--- a/pages/documentation/platforms/python.html
+++ b/pages/documentation/platforms/python.html
@@ -81,24 +81,15 @@
 		Install the Python runtime
 	</h2>
 	<div class="step-info">
-		Haxe requires Python 3.x. Due to security fixes and new features Python 3.6 or later is recommended. <br/><br/>
+		Haxe requires Python 3.x. Due to security fixes and new features Python 3.7 or later is recommended.<br/><br/>
 		
-		1. Install <a href="https://www.python.org/downloads/">Python 3.7</a> or later.
+		1. Install <a href="https://www.python.org/downloads/">Python 3.7</a> or later.<br/>
+		2. Test your installation by opening a command prompt and typing <code>python --version</code> or <code>python3 --version</code>.<br/>
 		<ul>
-			<li>Tested workflow on Windows: Install Python 3.7 64-bit for All Users</li>
-			<li>Python installer does not change any Registry values.</li>
-			<li>Python installer adds the installed Python directory to the PATH environment variable.</li>
+			<li>If your console cannot find <code>python</code>, you have an issue with your installation or <code>python</code> is not added into the <code>PATH</code> environment variable.</li>
+			<li>You should see something like the following:</li>
 		</ul>
-		2. Test your installation by opening a command prompt and typing "python". <br/>
-		<ul>
-			<li>If your console cannot find <code>python</code>, you have an issue with your installation or python is not added into the PATH environment variable.</li>
-			<li>You should see something like the following snippet.</li>
-		</ul>
-		<pre class="step-code">Python 3.7.2 (tags/v3.7.2:9a3ffc0492, Dec 23 2018, 23:09:28) [MSC v.1916 64 bit
-(AMD64)] on win32
-Type "help", "copyright", "credits" or "license" for more information.
->>></pre>
-		The <code>&gt;&gt;&gt;</code> prompt is from the Python interpreter and shows it is ready to run <code>.py</code> scripts. <br/>
+		<pre class="step-code">Python 3.7.2</pre>
 	</div>
 </div>
 
@@ -112,13 +103,13 @@ Type "help", "copyright", "credits" or "license" for more information.
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/python/index.html">Haxe Python API website</a> for the Python-specific API available. <br/>
+			Browse the <a href="https://api.haxe.org/python/index.html">Haxe Python API website</a> for the Python-specific API available.<br/>
 			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
-			Browse the <a href="https://lib.haxe.org/t/python/">haxelib</a> website for community-developed libraries that you can add to your project. <br/>
-			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>. <br/>
+			Browse the <a href="https://lib.haxe.org/t/python/">haxelib</a> website for community-developed libraries that you can add to your project.<br/>
+			You can install haxelib libraries globally by running <code>haxelib install &lt;library&gt;</code>.<br/>
 			You can specify that your project uses a haxelib by adding <code>-lib &lt;library&gt;</code> to your <code>.hxml</code> file.
 		</p>
 	</div>
@@ -134,12 +125,12 @@ Type "help", "copyright", "credits" or "license" for more information.
 	<div class="step-info">
 		<h4>Compilation</h4>
 		<p>
-			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory. <br/>
+			Build your Haxe project by running <code>haxe build.hxml</code> in a console in your project directory.<br/>
 			This compiles your <code>.hx</code> source code into Python scripts which you can run and debug next.
 		</p>
 		<h4>Running and debugging</h4>
 		<p>
-			After compiling your project with Haxe, you'll need to open a console in the <code>bin/python</code> directory and run the command <code>python main.py</code> <br/>
+			After compiling your project with Haxe, you'll need to open a console in the <code>bin/python</code> directory and run the command <code>python main.py</code><br/>
 			You can alternatively use a full-fledged Python IDE like the ones given below to run and debug your script easily.
 		</p>
 		<h4>Install a Python IDE</h4>

--- a/pages/documentation/platforms/python.html
+++ b/pages/documentation/platforms/python.html
@@ -103,8 +103,8 @@
 	<div class="step-info">
 		<h4>Haxe API</h4>
 		<p>
-			Browse the <a href="https://api.haxe.org/python/index.html">Haxe Python API website</a> for the Python-specific API available.<br/>
-			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe platform API that you can use in your project.
+			Browse the <a href="https://api.haxe.org/">Haxe API website</a> for the core Haxe APIs that you can use in your project.<br/>
+			You can use <a href="https://api.haxe.org/python/">Python-specific APIs</a> in addition to the core Haxe APIs.
 		</p>
 		<h4>Haxe libraries</h4>
 		<p>
@@ -130,11 +130,11 @@
 		</p>
 		<h4>Running and debugging</h4>
 		<p>
-			After compiling your project with Haxe, you'll need to open a console in the <code>bin/python</code> directory and run the command <code>python main.py</code><br/>
-			You can alternatively use a full-fledged Python IDE like the ones given below to run and debug your script easily.
+			After compiling your project with Haxe, you'll need to open a console in the <code>bin/python</code> directory and run the command <code>python main.py</code>.<br/>
+			You can alternatively use a full-fledged Python IDE like the ones given below to run and debug your program.
 		</p>
 		<h4>Install a Python IDE</h4>
-		If you want a better debugging experience, you can install a Python IDE to run and debug your Python scripts generated from your Haxe project.
+		If you want a better debugging experience, you can install a Python IDE to run and debug the Python code generated from your Haxe project.
 		<ul>
 			<li><a href="https://sourceforge.net/projects/pyscripter/">PyScripter</a></li>
 			<li><a href="https://visualstudio.microsoft.com/downloads/">Visual Studio 2017 Community Edition</a></li>


### PR DESCRIPTION
 - fix typos, mistakes, step numbering
 - make individual guides generally use the same wording for consistency
 - use `pre` for code snippets