### PR TITLE
Added JVM bytecode to compiler-targets doc

### DIFF
--- a/pages/documentation/introduction/compiler-targets.md
+++ b/pages/documentation/introduction/compiler-targets.md
@@ -17,6 +17,7 @@ Lua | source | No | Yes | 3.3 (2016)
 PHP7 | source | No | Yes | 3.4 (2016)
 [Neko](https://nekovm.org/) | byte code | No | Yes | alpha (2005)
 [HashLink](https://hashlink.haxe.org/) | byte code + source | Yes | Yes | 3.4 (2016)
+JVM | byte code | Yes | Yes | 4.0 (2019)
 
 > **Note:**
 > 


### PR DESCRIPTION
Though I haven't used this target, I noticed in the "What's new in 4.0" doc that JVM is now here.