### PR TITLE
Change manual deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "manual"]
-	path = manual
-	url = https://github.com/HaxeFoundation/HaxeManual.git
 [submodule "haxe-TmLanguage"]
 	path = grammars/haxe-TmLanguage
 	url = https://github.com/vshaxe/haxe-TmLanguage.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
   - mkdir -p ~/.fonts
   - cp NotoSans-Regular.ttf ~/.fonts
   - fc-cache -f -v
+  # checkout HaxeManual
+  - git checkout https://github.com/HaxeFoundation/HaxeManual.git manual
   # install awscli
   - pip3 install --user awscli
   - aws --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - cp NotoSans-Regular.ttf ~/.fonts
   - fc-cache -f -v
   # checkout HaxeManual
-  - git checkout https://github.com/HaxeFoundation/HaxeManual.git manual
+  - git clone https://github.com/HaxeFoundation/HaxeManual.git manual
   # install awscli
   - pip3 install --user awscli
   - aws --version

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The haxe.org website was designed to be easy to generate, to run a local copy fo
 ### Setting up
 
 * Install the dependencies `haxelib install all` and `npm install` in the root directory.
-* Update submodule dependencies `git submodule init && git submodule update`
+* Update submodule dependencies `git submodule init && git submodule update`.
+* Clone the manual into the `manual` directory with `git clone https://github.com/HaxeFoundation/HaxeManual.git manual`.
 * Generate the website by running `haxe generate.hxml`.
 
 The website is now available in the `out/` folder, you can launch it with `nekotools server -d out` and access it at `http://localhost:2000/`.

--- a/src/generators/Manual.hx
+++ b/src/generators/Manual.hx
@@ -57,6 +57,12 @@ class Manual {
 	public static function generate () {
 		Sys.println("Generating manual ...");
 
+		if (!FileSystem.exists(inPath)) {
+			Sys.println("Manual content not found!");
+			Sys.println("Please clone the manual with: git clone https://github.com/HaxeFoundation/HaxeManual.git manual");
+			return;
+		}
+
 		// Parse sections
 		var chapterFiles = FileSystem.readDirectory(inPath).filter(~/^[0-9]{2}-([^\.]+)\.md$/.match);
 		chapterFiles.sort(Reflect.compare);


### PR DESCRIPTION
Closes https://github.com/HaxeFoundation/HaxeManual/issues/424

This PR changes how the manual is deployed. It is no longer a submodule, which means it does not need to be updated in this repo manually. Instead, any Travis build will use the latest available commit on the master branch of `HaxeManual`.

For local development, `manual` needs to be a directory created either by cloning the `HaxeManual` repo, or by symlinking to an existing repo containing the manual. The `Manual.hx` generator [warns](https://github.com/HaxeFoundation/haxe.org/pull/414/files#diff-ab717cfe57cd8d33adb019f6f2b94069R60-R64) when the `manual` directory doesn't exist.