### PR TITLE
Update version numbers on documentation intro

### DIFF
--- a/pages/documentation/introduction/index.html
+++ b/pages/documentation/introduction/index.html
@@ -18,7 +18,7 @@
 		<div class="header"><a href="/manual/introduction.html" class="fa fa-book"></a>
 			<h5><a href="/manual/introduction.html">Manual</a></h5>
 		</div>
-		<p>A comprehensive manual for Haxe 3.  (This assumes a familiarity with general programming concepts, it is not a beginner's tutorial.)</p>
+		<p>A comprehensive manual for Haxe 4.  (This assumes a familiarity with general programming concepts, it is not a beginner's tutorial.)</p>
 		<p>
 			&raquo; <a href="/manual/introduction.html">Haxe Manual</a><br/>		
 			&raquo; <a href="/manual/introduction-about-this-document.html">About the manual</a>
@@ -28,10 +28,10 @@
 		<div class="header"><a href="/api/" class="fa fa-cogs"></a>
 			<h5><a href="/api/">API Docs</a></h5>
 		</div>
-		<p>Complete API documentation for the <a href="/documentation/introduction/stdlib-introduction.html">Haxe 3 Standard Library</a>.</p>
+		<p>Complete API documentation for the <a href="/documentation/introduction/stdlib-introduction.html">Haxe 4 Standard Library</a>.</p>
 		<p>
 			&raquo; <a href="/api/">API Documentation</a><br/>
-			&raquo; <a href="https://github.com/HaxeFoundation/haxe/releases/download/3.4.3/api-3.4.3.zip">Offline API Documentation (Zip)</a>
+			&raquo; <a href="https://github.com/HaxeFoundation/haxe/releases/download/3.4.3/api-3.4.3.zip">Offline API 3 Documentation (Zip)</a>
 		</p>
 	</div>
 </div>

--- a/pages/documentation/introduction/index.html
+++ b/pages/documentation/introduction/index.html
@@ -31,7 +31,7 @@
 		<p>Complete API documentation for the <a href="/documentation/introduction/stdlib-introduction.html">Haxe 4 Standard Library</a>.</p>
 		<p>
 			&raquo; <a href="/api/">API Documentation</a><br/>
-			&raquo; <a href="https://github.com/HaxeFoundation/haxe/releases/download/3.4.3/api-3.4.3.zip">Offline API 3 Documentation (Zip)</a>
+			&raquo; <a href="https://github.com/HaxeFoundation/haxe/releases/download/3.4.3/api-3.4.3.zip">Offline Haxe 3 API Documentation</a>
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
I'm not 100% sure, but with Haxe 4 existing for some time already and with it being mentioned on the front page and referenced many times in the docs, it looks like the version number should be updated here as well.

The generated API docs, from what I can see, were last made for 3.4.3 release and never again. It would be good to regenerate the docs zip for Haxe 4, or failing that, to remove the link altogether; for now, I just added version number to the link.