### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: haxe
 haxe:
   - "4.2.2"
 
-dist: xenial
+dist: bionic
 
 addons:
   apt:


### PR DESCRIPTION
It previously used Ubuntu 16.04 which had an out of date version of python, causing the aws script to break.