### PR TITLE
Fix link to haxedevelop in editors-and-ides.html

### DIFF
--- a/pages/documentation/introduction/editors-and-ides.html
+++ b/pages/documentation/introduction/editors-and-ides.html
@@ -30,7 +30,7 @@
 	<dt>Links</dt>
 	<dd>
 		<ul>
-			<li><a href="http://www.haxedevelop.org">HaxeDevelop</a></li>
+			<li><a href="http://www.haxedevelop.com">HaxeDevelop</a></li>
 		</ul>
 	</dd>
 </dl>


### PR DESCRIPTION
The old domain is dead.