### PR TITLE
Update link to Haxepunk

### DIFF
--- a/pages/use-cases/games/index.html
+++ b/pages/use-cases/games/index.html
@@ -117,7 +117,7 @@
 				<p>Heaps is a cross platform graphics engine designed for high performance games. It's designed to leverage modern GPUs that are commonly available on both desktop and mobile devices. </p>
 			</li>
 			<li>
-				<h6><a href="http://haxepunk.com" rel="noopener">HaxePunk</a></h6>
+				<h6><a href="https://github.com/HaxePunk/HaxePunk" rel="noopener">HaxePunk</a></h6>
 				<p>A Haxe port of the <a href="https://useflashpunk.net/">FlashPunk</a> framework, designed to let you build your game on any platform.</p>
 			</li>
 			<li>


### PR DESCRIPTION
haxepunk.com seems to be taken over by a generic article spewing machine. Linking to github-repo instead.