### PR TITLE
Attempt to fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ addons:
     - python3-pip
     - python3-setuptools
 
+before_install:
+- nvm install 12
+
 install:
   - haxelib setup ~/haxelib
   # fonts for svg to png conversion

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - python3-setuptools
 
 before_install:
-- nvm install 12
+- nvm install 8
 
 install:
   - haxelib setup ~/haxelib


### PR DESCRIPTION
The node dependencies we use are really old and do not work with modern versions of node, so we need to use version ~12~ 8.

Taken from: https://stackoverflow.com/questions/44249044/how-can-i-install-a-specific-node-js-version-on-a-php-container-on-travis-ci