### PR TITLE
Fix order of windows downloads

### DIFF
--- a/src/DownloadsData.hx
+++ b/src/DownloadsData.hx
@@ -163,7 +163,7 @@ class DownloadsData {
 				downloads.osx.archives.push(current = getInfo("OS X Binaries", url));
 				downloads.all.unshift(current);
 			} else if (filename.endsWith("-win.exe")) {
-				downloads.windows.installers.unshift(current = getInfo("Windows 32-bit Installer", url));
+				downloads.windows.installers.push(current = getInfo("Windows 32-bit Installer", url));
 				downloads.all.unshift(current);
 			} else if (filename.endsWith("-win.zip")) {
 				downloads.windows.archives.push(current = getInfo("Windows 32-bit Binaries", url));
@@ -172,7 +172,7 @@ class DownloadsData {
 				downloads.windows.installers.unshift(current = getInfo("Windows 64-bit Installer", url));
 				downloads.all.unshift(current);
 			} else if (filename.endsWith("-win64.zip")) {
-				downloads.windows.archives.push(current = getInfo("Windows 64-bit Binaries", url));
+				downloads.windows.archives.unshift(current = getInfo("Windows 64-bit Binaries", url));
 				downloads.all.unshift(current);
 			} else if (filename == 'api-${version.version}.zip') {
 				version.api = getInfo("API Documentation", url);


### PR DESCRIPTION
Minor issue, but it's been bothering me for a few days...

Currently, it's:
![image](https://user-images.githubusercontent.com/41230637/230729021-03b38b7c-628e-4d00-9994-b2f2b7588b24.png)


This fixes it to be:
![image](https://user-images.githubusercontent.com/41230637/230728993-be5c8239-d6d8-4f20-a3ee-75682ad26d99.png)
