### PR TITLE
Removed StablexUI from list of frameworks

### DIFF
--- a/pages/use-cases/mobile/index.html
+++ b/pages/use-cases/mobile/index.html
@@ -36,10 +36,6 @@
 				<h6><a href="http://haxeui.org/">HaxeUI</a></h6>
 				<p>A collection of touch-friendly UI components to use with OpenFL, NME, Flash or Adobe AIR.</p>
 			</li>
-			<li>
-				<h6><a href="https://github.com/RealyUniqueName/StablexUI">StablexUI</a></h6>
-				<p>A macro powered UI framework for use on OpenFL, NME, Flash or Adobe AIR.</p>
-			</li>
 		</ul>
 	</div>
 	<div class="span6">


### PR DESCRIPTION
Removed the mention of StablexUI from mobile use cases since it's abandoned for a long time.