### PR TITLE
Remove Waxe from the Desktop Apps page

### DIFF
--- a/pages/use-cases/desktop/index.html
+++ b/pages/use-cases/desktop/index.html
@@ -59,10 +59,6 @@
 				<p>OpenFL enables creative expression for the desktop, mobile and web. Enterprise applications and best-selling games are made with OpenFL, publishing native, Flash and HTML5 applications using one seamless toolset.</p>
 			</li>
 			<li>
-				<h6><a href="http://nmehost.com/waxe/">Waxe</a></h6>
-				<p>Use WxWidgets to create desktop apps with a truly native look and feel on all major platforms.  Works with the C++ and Neko targets, and integrates with NME. Start with these <a href="https://cambiatablog.wordpress.com/category/waxe/">Waxe tutorials by Cambiata</a> (Haxe 2).</p>
-			</li>
-			<li>
 				<h6>Have a suggestion?</h6>
 				<p><a href="https://github.com/HaxeFoundation/haxe.org/issues/new?title=Use-case%20suggestion">Let us know</a> and we might add it to this list.</p>
 			</li>


### PR DESCRIPTION
This is a minor pull request that removes Waxe's website from the list of suggested desktop UI libraries. Their website is offline and it doesn't seem to be actively maintained anymore.