### PR TITLE
Add sans-serif as fall back for nav bar element

### DIFF
--- a/www/css/haxe-nav.css
+++ b/www/css/haxe-nav.css
@@ -117,7 +117,7 @@ nav .navbar .nav>li>.dropdown-menu:after {
 	background: linear-gradient(to bottom,  #39332d 50%,#2c2722 51%); /* W3C */
 	padding:14px 20px 13px 20px;
 	margin:0 10px 0 0;
-	font:bold 18px "arial black", "open sans";
+	font:bold 18px "arial black", "open sans", sans-serif;
 	line-height:22px;
 	color:rgb(255,255,255);
 }


### PR DESCRIPTION
This css seems to be copied for the community.haxe.org page, but over there the open sans font hasn't been loaded like on haxe.org which results in the font being incorrect.

Other parts of the css in this repo do include this fallback, so it is a good idea anyway.